### PR TITLE
Fix null container property when it is not set from external API

### DIFF
--- a/main.go
+++ b/main.go
@@ -263,7 +263,14 @@ func CreateRun(algorithmName *C.char, algorithmParameters *C.char, customConfigu
 	if customConfiguration != nil {
 		var cpuLimit api.OptString
 		var memoryLimit api.OptString
-		var container api.OptV1NexusAlgorithmContainer
+		container := api.OptV1NexusAlgorithmContainer{
+			Value: api.V1NexusAlgorithmContainer{
+				VersionTag: api.OptString{
+					Set: false,
+				},
+			},
+			Set: true,
+		}
 		var workgroup api.OptV1NexusAlgorithmWorkgroupRef
 
 		if customConfiguration.cpu_limit != nil {


### PR DESCRIPTION
Prevents deserialization failure on `metadata` endpoint for `configuration_overrides`:

```
Error: failed to retrieve metadata for the template auto-replenishment-orchestrator-stores with run id c9dd0f1f-fa3f-42ad-b100-f8da9ba70202: decode response: decode application/json: decode ModelsCheckpointedRequest: callback: decode field "configuration_overrides": decode V1NexusAlgorithmSpec: callback: decode field "container": decode V1NexusAlgorithmContainer: "{" expected: unexpected byte 110 'n' at 3674
```

Reason:

```
 configuration_overrides
-------------------------------------------------------------------------------------------------------------------------------
 {"container":null,"computeResources":{"cpuLimit":"","memoryLimit":""},"command":"","runtimeEnvironment":{"maximumRetries":0}}
```